### PR TITLE
Cleanup

### DIFF
--- a/src/crop.sol
+++ b/src/crop.sol
@@ -91,7 +91,7 @@ contract CropJoin {
         return sub(bonus.balanceOf(address(this)), stock);
     }
 
-    // decimals: underlying=dec cToken=8 comp=18 gem=18
+    // decimals: underlying=dec bonus=18 gem=18
     function join(uint256 val) public {
         uint256 wad = wdiv(mul(val, 10 ** (18 - dec)), nps());
         require(int256(wad) >= 0);
@@ -118,7 +118,7 @@ contract CropJoin {
         if (total > 0) share = add(share, rdiv(crop(), total));
 
         address usr = msg.sender;
-        require(bonus.transfer(msg.sender, sub(rmul(stake[usr], share), crops[usr])));
+        require(bonus.transfer(usr, sub(rmul(stake[usr], share), crops[usr])));
         stock = bonus.balanceOf(address(this));
         if (wad > 0) {
             require(gem.transfer(usr, val));

--- a/src/crop.sol
+++ b/src/crop.sol
@@ -2,11 +2,11 @@ pragma solidity ^0.6.7;
 pragma experimental ABIEncoderV2;
 
 interface ERC20 {
-    function balanceOf(address owner) external view returns (uint);
-    function transfer(address dst, uint amount) external returns (bool);
-    function transferFrom(address src, address dst, uint amount) external returns (bool);
-    function approve(address spender, uint amount) external returns (bool);
-    function allowance(address owner, address spender) external view returns (uint);
+    function balanceOf(address owner) external view returns (uint256);
+    function transfer(address dst, uint256 amount) external returns (bool);
+    function transferFrom(address src, address dst, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
     function decimals() external returns (uint8);
 }
 
@@ -18,7 +18,7 @@ struct Urn {
 interface VatLike {
     function slip(bytes32 ilk, address usr, int256 wad) external;
     function flux(bytes32 ilk, address src, address dst, uint256 wad) external;
-    function  gem(bytes32 ilk, address usr) external returns (uint);
+    function  gem(bytes32 ilk, address usr) external returns (uint256);
     function urns(bytes32 ilk, address usr) external returns (Urn memory);
 }
 
@@ -33,8 +33,8 @@ contract CropJoin {
     uint256     public total;  // total gems       [wad]
     uint256     public stock;  // crop balance     [wad]
 
-    mapping (address => uint) public crops; // crops per user  [wad]
-    mapping (address => uint) public stake; // gems per user   [wad]
+    mapping (address => uint256) public crops; // crops per user  [wad]
+    mapping (address => uint256) public stake; // gems per user   [wad]
 
     ERC20       public bonus;  // rewards token
 
@@ -48,62 +48,62 @@ contract CropJoin {
         bonus = ERC20(bonus_);
     }
 
-    function add(uint x, uint y) public pure returns (uint z) {
+    function add(uint256 x, uint256 y) public pure returns (uint256 z) {
         require((z = x + y) >= x, "ds-math-add-overflow");
     }
-    function sub(uint x, uint y) public pure returns (uint z) {
+    function sub(uint256 x, uint256 y) public pure returns (uint256 z) {
         require((z = x - y) <= x, "ds-math-sub-underflow");
     }
-    function mul(uint x, uint y) public pure returns (uint z) {
+    function mul(uint256 x, uint256 y) public pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x, "ds-math-mul-overflow");
     }
     uint256 constant WAD  = 10 ** 18;
-    function wmul(uint x, uint y) public pure returns (uint z) {
+    function wmul(uint256 x, uint256 y) public pure returns (uint256 z) {
         z = mul(x, y) / WAD;
     }
-    function wdiv(uint x, uint y) public pure returns (uint z) {
+    function wdiv(uint256 x, uint256 y) public pure returns (uint256 z) {
         z = mul(x, WAD) / y;
     }
     uint256 constant RAY  = 10 ** 27;
-    function rmul(uint x, uint y) public pure returns (uint z) {
+    function rmul(uint256 x, uint256 y) public pure returns (uint256 z) {
         z = mul(x, y) / RAY;
     }
-    function rdiv(uint x, uint y) public pure returns (uint z) {
+    function rdiv(uint256 x, uint256 y) public pure returns (uint256 z) {
         z = mul(x, RAY) / y;
     }
-    function min(uint x, uint y) internal pure returns (uint z) {
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return x <= y ? x : y;
     }
 
     // Net Asset Valuation [wad]
-    function nav() public virtual returns (uint) {
-        uint _nav = gem.balanceOf(address(this));
+    function nav() public virtual returns (uint256) {
+        uint256 _nav = gem.balanceOf(address(this));
         return mul(_nav, 10 ** (18 - dec));
     }
 
     // Net Assets per Share [wad]
-    function nps() public returns (uint) {
+    function nps() public returns (uint256) {
         if (total == 0) return WAD;
         else return wdiv(nav(), total);
     }
 
-    function crop() internal virtual returns (uint) {
+    function crop() internal virtual returns (uint256) {
         return sub(bonus.balanceOf(address(this)), stock);
     }
 
     // decimals: underlying=dec cToken=8 comp=18 gem=18
     function join(uint256 val) public {
-        uint wad = wdiv(mul(val, 10 ** (18 - dec)), nps());
-        require(int(wad) >= 0);
+        uint256 wad = wdiv(mul(val, 10 ** (18 - dec)), nps());
+        require(int256(wad) >= 0);
 
         if (total > 0) share = add(share, rdiv(crop(), total));
 
         address usr = msg.sender;
-        require(bonus.transfer(msg.sender, sub(rmul(stake[usr], share), crops[usr])));
+        require(bonus.transfer(usr, sub(rmul(stake[usr], share), crops[usr])));
         stock = bonus.balanceOf(address(this));
         if (wad > 0) {
             require(gem.transferFrom(usr, address(this), val));
-            vat.slip(ilk, usr, int(wad));
+            vat.slip(ilk, usr, int256(wad));
 
             total = add(total, wad);
             stake[usr] = add(stake[usr], wad);
@@ -111,9 +111,9 @@ contract CropJoin {
         crops[usr] = rmul(stake[usr], share);
     }
 
-    function exit(uint val) public {
-        uint wad = wdiv(mul(val, 10 ** (18 - dec)), nps());
-        require(int(wad) >= 0);
+    function exit(uint256 val) public {
+        uint256 wad = wdiv(mul(val, 10 ** (18 - dec)), nps());
+        require(int256(wad) >= 0);
 
         if (total > 0) share = add(share, rdiv(crop(), total));
 
@@ -122,7 +122,7 @@ contract CropJoin {
         stock = bonus.balanceOf(address(this));
         if (wad > 0) {
             require(gem.transfer(usr, val));
-            vat.slip(ilk, usr, -int(wad));
+            vat.slip(ilk, usr, -int256(wad));
 
             total = sub(total, wad);
             stake[usr] = sub(stake[usr], wad);
@@ -133,8 +133,8 @@ contract CropJoin {
     function flee() public {
         address usr = msg.sender;
 
-        uint wad = vat.gem(ilk, usr);
-        uint val = wmul(wmul(wad, nps()), 10 ** dec);
+        uint256 wad = vat.gem(ilk, usr);
+        uint256 val = wmul(wmul(wad, nps()), 10 ** dec);
 
         require(gem.transfer(usr, val));
         vat.slip(ilk, usr, -int(wad));
@@ -144,7 +144,7 @@ contract CropJoin {
         crops[usr] = rmul(stake[usr], share);
     }
 
-    function tack(address src, address dst, uint wad) public {
+    function tack(address src, address dst, uint256 wad) public {
         stake[src] = sub(stake[src], wad);
         stake[dst] = add(stake[dst], wad);
 


### PR DESCRIPTION
Mostly cleaning up the types uint -> uint256, int -> int256. Also, removed the mention of cToken as this join adapter should be agnostic to the rewards type. Use the `usr` variable instead of `msg.sender`.